### PR TITLE
Align sortable and non-sortable table headers

### DIFF
--- a/src/components/TableHeader/SortLabel.tsx
+++ b/src/components/TableHeader/SortLabel.tsx
@@ -14,6 +14,8 @@ const useStyles = makeStyles((theme) =>
       display: "inline-grid",
     },
     sortButton: {
+      fontSize: "inherit",
+      fontFamily: "inherit",
       "&:focus": {
         color: theme.palette.text.secondary,
       },

--- a/src/components/makeAdhocList.tsx
+++ b/src/components/makeAdhocList.tsx
@@ -76,6 +76,11 @@ const useStyles = makeStyles((theme) =>
       top: 0,
       paddingLeft: "1em",
     },
+    nonSortableHeaderLabel: {
+      display: "inline-flex",
+      verticalAlign: "middle",
+      lineHeight: "normal",
+    },
     offScreen: {
       position: "absolute",
       left: "-10000px",
@@ -557,7 +562,17 @@ const makeAdhocList = <DataShape extends {}>() => {
                         </TableCell>
                       );
                     }
-                    return <TableCell key={i}>{title}</TableCell>;
+                    return (
+                      <TableCell
+                        key={i}
+                        className={classes.headerCell}
+                        padding="none"
+                      >
+                        <span className={classes.nonSortableHeaderLabel}>
+                          <b>{title}</b>
+                        </span>
+                      </TableCell>
+                    );
                   })}
                 </TableRow>
               </TableHead>


### PR DESCRIPTION
## Summary

This makes `AdhocList` render sortable and non-sortable column headers through symmetric layout/style paths.

- `SortLabel`'s `ButtonBase` now inherits the surrounding `font-size` and `font-family` instead of using browser button defaults.
- Non-sortable headers now use the same sticky header cell, `padding="none"`, bold title, and inline-flex label box as sortable headers.
- The only remaining intentional difference is the sortable affordance: the interactive button and sort arrows.

## Background

The current header rendering split appears to be additive feature drift rather than an intentional visual distinction.

Before column sorting was added, every header rendered as a plain `TableCell`. Commit `03af982` (`Implement column sorting`) added a richer sortable-header path with `headerCell`, `padding="none"`, `Tooltip`, and `SortLabel`, but left the non-sortable fallback as the original bare `TableCell`. Commit `ad45b36` (`Add SortLabel`) introduced the `ButtonBase` + bold label + arrow wrapper used by sortable headers. Later commits carried that split forward.

So mixed tables now have two different header implementations: sortable columns use the newer styled/interactable path, while non-sortable columns keep the older plain path.

## Why

In a table with both sortable and non-sortable columns, those two paths produce different boxes and typography:

- sortable headers use `headerCell`, sticky positioning, `padding="none"`, `ButtonBase`, and `<b>{label}</b>`
- non-sortable headers use default `TableCell` padding and plain text

There is also a subtle font mismatch: browser controls can use their own UA font unless the button inherits `font-family`. In applications with a custom app font, the sortable `ButtonBase` label can resolve line height against a different typeface than the plain non-sortable header. That makes the alignment issue persist even after matching weight/size in consumer code.

Fixing this in the library keeps consumers from adding one-off column styles and makes the two header branches reflect the same component contract.

## Impact

For mixed sortable/non-sortable tables, non-sortable headers now visually align with sortable siblings. The sort arrows remain exclusive to sortable columns.

For tables where every column is non-sortable, headers now use the library's sortable-header style: bold, sticky, and `padding="none"` with the existing `headerCell` padding. This is a visible change, but it is consistent with the library's established styled header path.

JSX titles in non-sortable headers are now wrapped in `<b>` inside the label span, matching the existing sortable path. A block-level title such as `title={<div />}` can therefore become invalid nested markup under `<b>`, but that behavior already exists for sortable headers today; this PR does not introduce a new asymmetry there.

## Validation

- Confirmed the current source has two asymmetric header render paths.
- Checked commit history to verify the asymmetry originated when sorting added a richer sortable path and preserved the old plain fallback for non-sortable headers.
- Installed dependencies with `corepack yarn install --frozen-lockfile`.
- Ran TypeScript successfully via `./node_modules/.bin/tsc.cmd --outDir lib`.

Note: `corepack yarn build` did not find `tsc` on PATH in this Windows shell, so I invoked the local TypeScript binary directly with the same build argument.